### PR TITLE
Update xs2awizard-android library to 5.2.3

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -126,7 +126,7 @@ dependencies {
   // noinspection GradleDynamicVersion
   api 'com.facebook.react:react-native:+'
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  implementation "com.fintecsystems:xs2awizard:5.0.1"
+  implementation "com.fintecsystems:xs2awizard:5.2.3"
 
   constraints {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.0") {


### PR DESCRIPTION
There have been some bug fixes in the latest xs2awizard-android library, which are probably relevant for us, so we'd like to upgrade that dependency. 

It would be great if this could be merged and released, so we dont have to patch this library manually