### PR TITLE
chore: update android SDK to latest version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -126,7 +126,7 @@ dependencies {
   // noinspection GradleDynamicVersion
   api 'com.facebook.react:react-native:+'
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  implementation "com.fintecsystems:xs2awizard:5.0.1"
+  implementation "com.fintecsystems:xs2awizard:5.2.6"
 
   constraints {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.0") {


### PR DESCRIPTION
This library is not usable with latest react / expo versions on Android.
An update fixes the issue.